### PR TITLE
chore: Add support for OpenTofu language constructs in *.tofu files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ HCL syntax is checked for e.g. missing control characters like `}`, `"` or other
 
 ![](docs/validation-rule-hcl.png)
 
-Enhanced validation of selected OpenTofu language constructs in both `*.tf` and `*.tfvars` files based on detected OpenTofu version and provider versions is also provided. This can highlight deprecations, missing required attributes or blocks, references to undeclared variables and more, [as documented](https://github.com/hashicorp/terraform-ls/blob/main/docs/validation.md#enhanced-validation).
+Enhanced validation of selected OpenTofu language constructs in `*.tf`,  `*.tfvars` and `*.tofu` files based on detected OpenTofu version and provider versions is also provided. This can highlight deprecations, missing required attributes or blocks, references to undeclared variables and more, [as documented](https://github.com/hashicorp/terraform-ls/blob/main/docs/validation.md#enhanced-validation).
 
 ![](docs/validation-rule-missing-attribute.png)
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "activationEvents": [
     "onView:opentofu-modules",
     "workspaceContains:**/*.tf",
+    "workspaceContains:**/*.tofu",
     "workspaceContains:**/*.tfvars"
   ],
   "main": "./out/extension",
@@ -65,7 +66,8 @@
           "hcl"
         ],
         "extensions": [
-          ".tf"
+          ".tf",
+          ".tofu"
         ],
         "configuration": "./language-configuration.json"
       },

--- a/test/fixtures/actions.tf
+++ b/test/fixtures/actions.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 terraform {
   # code that needs to be formatted
                 }

--- a/test/fixtures/ai/main.tf
+++ b/test/fixtures/ai/main.tf
@@ -1,0 +1,3 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+

--- a/test/fixtures/ai/variables.tf
+++ b/test/fixtures/ai/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "agi" {
   default = false
 }

--- a/test/fixtures/compute/main.tf
+++ b/test/fixtures/compute/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 resource "google_compute_network" "vpc_network" {
   name = "terraform-network"

--- a/test/fixtures/compute/outputs.tf
+++ b/test/fixtures/compute/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 output "ip" {
   value = google_compute_instance.vm_instance.network_interface[0].network_ip
 }

--- a/test/fixtures/compute/variables.tf
+++ b/test/fixtures/compute/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "instance_name" {
   type        = string
   description = "Name of the compute instance"

--- a/test/fixtures/empty.tf
+++ b/test/fixtures/empty.tf
@@ -1,0 +1,3 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+

--- a/test/fixtures/main.tf
+++ b/test/fixtures/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 terraform {
   required_providers {
     google = {

--- a/test/fixtures/sample.tf
+++ b/test/fixtures/sample.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 provider "vault" {
 }
 

--- a/test/fixtures/terraform.tfvars
+++ b/test/fixtures/terraform.tfvars
@@ -1,1 +1,4 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 zone = "us-central1-c"

--- a/test/fixtures/variables.tf
+++ b/test/fixtures/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 variable "project" {
   type = string
 }


### PR DESCRIPTION
Since Opentofu 1.8, the extension `.tofu` was added to the project: https://opentofu.org/docs/language/files/

